### PR TITLE
Fix DB session cleanup

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -22,6 +22,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 class DBSessionMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         db_session = None
+        db_gen = None
         try:
             # Get database session using the dependency
             db_gen = get_db()
@@ -38,6 +39,8 @@ class DBSessionMiddleware(BaseHTTPMiddleware):
             # Always close the session if we created one
             if db_session:
                 await db_session.close()
+            if db_gen is not None:
+                await db_gen.aclose()
 
 
 def make_middleware() -> list[Middleware]:


### PR DESCRIPTION
## Summary
- close the get_db async generator in DBSessionMiddleware

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_b_6849209021c08332afcfe77b28c4be50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource management to ensure database connections are properly closed after each request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->